### PR TITLE
feat(api): Add `difficulty`, `network-hashrate` and `peers` endpoint

### DIFF
--- a/app/api/difficulty/route.ts
+++ b/app/api/difficulty/route.ts
@@ -1,0 +1,40 @@
+import { type NextRequest, NextResponse } from "next/server"
+import { getNetworkStats } from "@/lib/data"
+import { rateLimit } from "@/lib/rate-limit"
+
+export async function GET(request: NextRequest) {
+  try {
+    // Get client IP
+    const ip = request.ip || request.headers.get("x-forwarded-for") || request.headers.get("x-real-ip") || "unknown"
+
+    // Apply rate limiting (60 requests per minute)
+    if (!rateLimit(ip, 60, 60000)) {
+      return new NextResponse("Rate limit exceeded", {
+        status: 429,
+        headers: {
+          "Content-Type": "text/plain",
+          "Retry-After": "60",
+        },
+      })
+    }
+
+    const networkStats = await getNetworkStats()
+
+    return new NextResponse(networkStats.difficulty_pow, {
+      status: 200,
+      headers: {
+        "Content-Type": "text/plain",
+        "Cache-Control": "public, max-age=30",
+      },
+    })
+  } catch (error) {
+    console.error("Error in difficulty API route:", error)
+
+    return new NextResponse("0.0000000000", {
+      status: 500,
+      headers: {
+        "Content-Type": "text/plain",
+      },
+    })
+  }
+}

--- a/app/api/network-hashrate/route.ts
+++ b/app/api/network-hashrate/route.ts
@@ -1,0 +1,40 @@
+import { type NextRequest, NextResponse } from "next/server"
+import { rpcCall } from "@/lib/data"
+import { rateLimit } from "@/lib/rate-limit"
+
+export async function GET(request: NextRequest) {
+  try {
+    // Get client IP
+    const ip = request.ip || request.headers.get("x-forwarded-for") || request.headers.get("x-real-ip") || "unknown"
+
+    // Apply rate limiting (60 requests per minute)
+    if (!rateLimit(ip, 60, 60000)) {
+      return new NextResponse("Rate limit exceeded", {
+        status: 429,
+        headers: {
+          "Content-Type": "text/plain",
+          "Retry-After": "60",
+        },
+      })
+    }
+
+    const networkHashRate = await rpcCall("getnetworkhashps", [120, -1])
+    
+    return new NextResponse(networkHashRate, {
+      status: 200,
+      headers: {
+        "Content-Type": "text/plain",
+        "Cache-Control": "public, max-age=30",
+      },
+    })
+  } catch (error) {
+    console.error("Error in network-hashrate API route:", error)
+
+    return new NextResponse("0.0000", {
+      status: 500,
+      headers: {
+        "Content-Type": "text/plain",
+      },
+    })
+  }
+}

--- a/app/api/page.tsx
+++ b/app/api/page.tsx
@@ -166,6 +166,84 @@ export default function APIPage() {
                 </div>
               </CardContent>
             </Card>
+
+            {/* Difficulty */}
+            <Card>
+              <CardHeader className="pb-3">
+                <CardTitle className="text-lg">Difficulty</CardTitle>
+                <CardDescription>Get the current difficulty</CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-3">
+                <div className="flex items-center gap-2">
+                  <Badge variant="outline">Plain Text</Badge>
+                  <a
+                    href="https://explorer.aegisum.com/api/difficulty"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-blue-600 hover:underline font-mono text-sm flex items-center gap-1"
+                  >
+                    /api/difficulty
+                    <ExternalLink className="h-3 w-3" />
+                  </a>
+                </div>
+                <div>
+                  <p className="text-sm font-medium mb-1">Example Output:</p>
+                  <code className="block bg-slate-100 dark:bg-slate-800 p-2 rounded text-sm">20574.6753725802</code>
+                </div>
+              </CardContent>
+            </Card>
+
+            {/* Network Hashrate */}       
+            <Card>
+              <CardHeader className="pb-3">
+                <CardTitle className="text-lg">Network Hashrate</CardTitle>
+                <CardDescription>Get the current network hashrate (hash/s)</CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-3">
+                <div className="flex items-center gap-2">
+                  <Badge variant="outline">Plain Text</Badge>
+                  <a
+                    href="https://explorer.aegisum.com/api/network-hashrate"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-blue-600 hover:underline font-mono text-sm flex items-center gap-1"
+                  >
+                    /api/network-hashrate
+                    <ExternalLink className="h-3 w-3" />
+                  </a>
+                </div>
+                <div>
+                  <p className="text-sm font-medium mb-1">Example Output:</p>
+                  <code className="block bg-slate-100 dark:bg-slate-800 p-2 rounded text-sm">473377087815.4365</code>
+                </div>
+              </CardContent>
+            </Card>
+
+            {/* Peers */}       
+            <Card>
+              <CardHeader className="pb-3">
+                <CardTitle className="text-lg">Peers</CardTitle>
+                <CardDescription>Get the number of connections the block explorer has to other nodes</CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-3">
+                <div className="flex items-center gap-2">
+                  <Badge variant="outline">Plain Text</Badge>
+                  <a
+                    href="https://explorer.aegisum.com/api/peers"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-blue-600 hover:underline font-mono text-sm flex items-center gap-1"
+                  >
+                    /api/peers
+                    <ExternalLink className="h-3 w-3" />
+                  </a>
+                </div>
+                <div>
+                  <p className="text-sm font-medium mb-1">Example Output:</p>
+                  <code className="block bg-slate-100 dark:bg-slate-800 p-2 rounded text-sm">22</code>
+                </div>
+              </CardContent>
+            </Card>
           </div>
 
           <Separator />
@@ -197,9 +275,12 @@ export default function APIPage() {
                   {`{
   "blockHeight": { "value": 34411, "formatted": "34,411" },
   "currentSupply": { "value": 19804000, "formatted": "19,804,000" },
-  "maxSupply": { "value": 100000000, "formatted": "100,000,000" },
-  "price": { "value": 0.00077, "formatted": "$0.00077000" },
+  "difficulty": { "value": 20574.6753725802, "formatted": "20,574.6753" },
   "marketCap": { "value": 15249.08, "formatted": "$15,249.08" },
+  "maxSupply": { "value": 100000000, "formatted": "100,000,000" },
+  "price": { "value": 0.00077000, "formatted": "$0.00077" },
+  "networkHashRate": { "value": 473377087815.4365, "formatted": "473.3771 GH/s" },
+  "peers": { "value": 22, "formatted": "22" },
   "supplyPercentage": { "value": 19.804, "formatted": "19.80%" },
   "timestamp": "2025-06-29T18:28:36.792Z",
   "network": "Aegisum",

--- a/app/api/peers/route.ts
+++ b/app/api/peers/route.ts
@@ -1,0 +1,40 @@
+import { type NextRequest, NextResponse } from "next/server"
+import { getNetworkStats } from "@/lib/data"
+import { rateLimit } from "@/lib/rate-limit"
+
+export async function GET(request: NextRequest) {
+  try {
+    // Get client IP
+    const ip = request.ip || request.headers.get("x-forwarded-for") || request.headers.get("x-real-ip") || "unknown"
+
+    // Apply rate limiting (60 requests per minute)
+    if (!rateLimit(ip, 60, 60000)) {
+      return new NextResponse("Rate limit exceeded", {
+        status: 429,
+        headers: {
+          "Content-Type": "text/plain",
+          "Retry-After": "60",
+        },
+      })
+    }
+
+    const networkStats = await getNetworkStats()
+
+    return new NextResponse(networkStats.connections, {
+      status: 200,
+      headers: {
+        "Content-Type": "text/plain",
+        "Cache-Control": "public, max-age=30",
+      },
+    })
+  } catch (error) {
+    console.error("Error in peers API route:", error)
+
+    return new NextResponse("0", {
+      status: 500,
+      headers: {
+        "Content-Type": "text/plain",
+      },
+    })
+  }
+}

--- a/app/api/summary/route.ts
+++ b/app/api/summary/route.ts
@@ -1,5 +1,5 @@
 import { type NextRequest, NextResponse } from "next/server"
-import { getNetworkStats } from "@/lib/data"
+import { getNetworkStats, rpcCall } from "@/lib/data"
 import { getAegsPrice } from "@/lib/price"
 import { rateLimit } from "@/lib/rate-limit"
 
@@ -26,7 +26,8 @@ export async function GET(request: NextRequest) {
     const priceNumber = Number.parseFloat(price)
     const maxSupply = 100000000 // 100 million AEGS
     const marketCap = networkStats.supply * priceNumber
-
+    const networkHashRate = await rpcCall("getnetworkhashps", [120, -1])
+    
     return NextResponse.json(
       {
         blockHeight: {
@@ -37,17 +38,29 @@ export async function GET(request: NextRequest) {
           value: networkStats.supply,
           formatted: networkStats.supply.toLocaleString(),
         },
+        difficulty: {
+          value: networkStats.difficulty_pow,
+          formatted: Number(networkStats.difficulty_pow).toLocaleString(undefined, { minimumFractionDigits: 0, maximumFractionDigits: 4 })
+        },
+        marketCap: {
+          value: marketCap,
+          formatted: `$${marketCap.toLocaleString(undefined, { minimumFractionDigits: 0, maximumFractionDigits: 2 })}`,
+        },
         maxSupply: {
           value: maxSupply,
           formatted: maxSupply.toLocaleString(),
         },
+        networkHashRate: {
+          value: networkHashRate,
+          formatted: `${Number(networkHashRate / 1000000000)} GH/s`
+        },
+        peers: {
+          value: networkStats.connections,
+          formatted: networkStats.connections.toLocaleString()
+        },
         price: {
           value: priceNumber,
           formatted: `$${price}`,
-        },
-        marketCap: {
-          value: marketCap,
-          formatted: `$${marketCap.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`,
         },
         supplyPercentage: {
           value: (networkStats.supply / maxSupply) * 100,

--- a/app/mining/page.tsx
+++ b/app/mining/page.tsx
@@ -92,7 +92,7 @@ export default async function MiningPage() {
               </div>
             </div>
             <div className="space-y-1">
-              <h3 className="text-2xl font-bold">{miningStats.networkhashps?.toFixed(4) || "0.0000"} GH/s</h3>
+              <h3 className="text-2xl font-bold">{Number(miningStats.networkhashps?.toFixed(4)) || "0.0000"} GH/s</h3>
               <p className="text-xs text-muted-foreground">Estimated network hashrate</p>
             </div>
           </CardContent>
@@ -133,7 +133,7 @@ export default async function MiningPage() {
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
             <div>
               <h3 className="text-sm font-medium text-muted-foreground mb-1">Difficulty</h3>
-              <p className="text-xl font-semibold">{miningStats.difficulty?.toFixed(4) || "0.0000"}</p>
+              <p className="text-xl font-semibold">{Number(miningStats.difficulty)?.toLocaleString(undefined, { minimumFractionDigits: 0, maximumFractionDigits: 4 }) || "0.0000"}</p>
             </div>
             <div>
               <h3 className="text-sm font-medium text-muted-foreground mb-1">Algorithm</h3>

--- a/lib/data.ts
+++ b/lib/data.ts
@@ -9,7 +9,7 @@ const RPC_PASS = process.env.RPC_PASS || "rpcpassword"
 const RPC_URL = `http://${RPC_USER}:${RPC_PASS}@${RPC_HOST}:${RPC_PORT}`
 
 // Helper function to make RPC calls
-async function rpcCall(method, params = []) {
+export async function rpcCall(method, params = []) {
   try {
     const response = await axios.post(RPC_URL, {
       jsonrpc: "1.0",


### PR DESCRIPTION
Added new endpoints 
- `difficulty` - Get the current difficulty
- `network-hashrate` - Get the current network hashrate (hash/s)
- `peers` - Get the number of connections the block explorer has to other nodes